### PR TITLE
Added doubleVal to YaraExpressionBuilder

### DIFF
--- a/include/yaramod/builder/yara_expression_builder.h
+++ b/include/yaramod/builder/yara_expression_builder.h
@@ -147,6 +147,7 @@ private:
 YaraExpressionBuilder intVal(std::int64_t value, IntMultiplier mult = IntMultiplier::None);
 YaraExpressionBuilder uintVal(std::uint64_t value, IntMultiplier mult = IntMultiplier::None);
 YaraExpressionBuilder hexIntVal(std::uint64_t value);
+YaraExpressionBuilder doubleVal(double value);
 YaraExpressionBuilder stringVal(const std::string& value);
 YaraExpressionBuilder boolVal(bool value);
 

--- a/src/builder/yara_expression_builder.cpp
+++ b/src/builder/yara_expression_builder.cpp
@@ -544,6 +544,18 @@ YaraExpressionBuilder hexIntVal(std::uint64_t value)
 }
 
 /**
+ * Creates the double expression from a number.
+ *
+ * @param value Double value.
+ *
+ * @return Builder.
+ */
+YaraExpressionBuilder doubleVal(double value)
+{
+	return YaraExpressionBuilder(std::make_shared<DoubleLiteralExpression>(numToStr(value)));
+}
+
+/**
  * Creates the string expression.
  *
  * @param value String value.

--- a/src/python/yaramod_python.cpp
+++ b/src/python/yaramod_python.cpp
@@ -435,6 +435,7 @@ void addBuilderClasses(py::module& module)
 	module.def("int_val", &intVal, py::arg("value"), py::arg("mult") = IntMultiplier::None);
 	module.def("uint_val", &uintVal, py::arg("value"), py::arg("mult") = IntMultiplier::None);
 	module.def("hex_int_val", &hexIntVal);
+	module.def("double_val", &doubleVal);
 	module.def("string_val", &stringVal);
 	module.def("bool_val", &boolVal);
 

--- a/tests/cpp/builder_tests.cpp
+++ b/tests/cpp/builder_tests.cpp
@@ -524,6 +524,29 @@ RuleWithArithmeticOperationsWorks) {
 }
 
 TEST_F(BuilderTests,
+RuleWithArithmeticOperationsWithDoubleValuesWorks) {
+	auto cond = (paren(entrypoint() + doubleVal(2.71828) * intVal(10)) < paren(filesize() - doubleVal(1.61803) / doubleVal(3.14159)))
+		.get();
+
+	YaraRuleBuilder newRule;
+	auto rule = newRule
+		.withName("rule_with_arithmetic_operations_with_double_values")
+		.withCondition(cond)
+		.get();
+
+	YaraFileBuilder newFile;
+	auto yaraFile = newFile
+		.withRule(std::move(rule))
+		.get();
+
+	ASSERT_NE(nullptr, yaraFile);
+	EXPECT_EQ(R"(rule rule_with_arithmetic_operations_with_double_values {
+	condition:
+		(entrypoint + 2.71828 * 10) < (filesize - 1.61803 \ 3.14159)
+})", yaraFile->getText());
+}
+
+TEST_F(BuilderTests,
 RuleWithBitwiseOperationsWorks) {
 	auto cond = (id("pe").access("characteristics") & paren(id("pe").access("DLL") | id("pe").access("RELOCS_STRIPPED")))
 		.get();

--- a/tests/python/test_builder.py
+++ b/tests/python/test_builder.py
@@ -134,6 +134,21 @@ import "elf"
 		true
 }''')
 
+    def test_rule_with_double_values(self):
+        cond = yaramod.double_val(3.14159) > yaramod.double_val(2.71828)
+        rule = self.new_rule \
+            .with_name('rule_with_double_values') \
+            .with_condition(cond.get()) \
+            .get()
+        yara_file = self.new_file \
+            .with_rule(rule) \
+            .get()
+
+        self.assertEqual(yara_file.text, '''rule rule_with_double_values {
+	condition:
+		3.14159 > 2.71828
+}''')
+
     def test_multiple_rules(self):
         rule1 = self.new_rule \
             .with_name('rule_1') \


### PR DESCRIPTION
Added `doubleVal` expression to builder (#22) . `doubleVal` also added to python bindings and to tests.