### PR TITLE
Removing duplicate python tests

### DIFF
--- a/tests/python/test_builder.py
+++ b/tests/python/test_builder.py
@@ -194,21 +194,6 @@ rule rule_2 : Tag2 {
 		$1 at 100
 }''')
 
-    def test_rule_with_string_at_condition(self):
-        cond = yaramod.match_at('$1', yaramod.int_val(100))
-        rule = self.new_rule \
-            .with_name('rule_with_string_id_condition') \
-            .with_condition(cond.get()) \
-            .get()
-        yara_file = self.new_file \
-            .with_rule(rule) \
-            .get()
-
-        self.assertEqual(yara_file.text, '''rule rule_with_string_id_condition {
-	condition:
-		$1 at 100
-}''')
-
     def test_rule_with_match_in_range_condition(self):
         cond = yaramod.match_in_range('$1', yaramod.range(yaramod.int_val(100), yaramod.int_val(200)))
         rule = self.new_rule \
@@ -650,10 +635,10 @@ rule rule_with_structure_access_condition {
 		pe.linker_version.major
 }''')
 
-    def test_rule_with_structure_access_condition(self):
-        cond = yaramod.id('pe').access('linker_version').access('major')
+    def test_rule_with_array_access_condition(self):
+        cond = yaramod.id('pe').access('sections')[yaramod.int_val(0)].access('name')
         rule = self.new_rule \
-            .with_name('rule_with_structure_access_condition') \
+            .with_name('rule_with_array_access_condition') \
             .with_condition(cond.get()) \
             .get()
         yara_file = self.new_file \
@@ -663,9 +648,27 @@ rule rule_with_structure_access_condition {
 
         self.assertEqual(yara_file.text, '''import "pe"
 
-rule rule_with_structure_access_condition {
+rule rule_with_array_access_condition {
 	condition:
-		pe.linker_version.major
+		pe.sections[0].name
+}''')
+
+    def test_rule_with_dictionary_access_condition(self):
+        cond = yaramod.id('pe').access('version_info')[yaramod.string_val('CompanyName')]
+        rule = self.new_rule \
+            .with_name('rule_with_dictionary_access_condition') \
+            .with_condition(cond.get()) \
+            .get()
+        yara_file = self.new_file \
+            .with_module('pe') \
+            .with_rule(rule) \
+            .get()
+
+        self.assertEqual(yara_file.text, '''import "pe"
+
+rule rule_with_dictionary_access_condition {
+	condition:
+		pe.version_info["CompanyName"]
 }''')
 
     def test_rule_with_complex_condition(self):

--- a/tests/python/test_parser.py
+++ b/tests/python/test_parser.py
@@ -452,9 +452,9 @@ rule less_equal_condition {
         self.assertTrue(isinstance(rule.condition.right_operand, yaramod.IntLiteralExpression))
         self.assertEqual(rule.condition.text, 'filesize <= 10')
 
-    def test_greater_than_condition(self):
+    def test_greater_equal_condition(self):
         yara_file = yaramod.parse_string('''
-rule greater_than_condition {
+rule greater_equal_condition {
     condition:
         filesize >= 10
 }''')
@@ -525,21 +525,6 @@ rule plus_condition {
         self.assertTrue(isinstance(rule.condition.left_operand, yaramod.KeywordExpression))
         self.assertTrue(isinstance(rule.condition.right_operand, yaramod.IntLiteralExpression))
         self.assertEqual(rule.condition.text, 'filesize + 10')
-
-    def test_minus_condition(self):
-        yara_file = yaramod.parse_string('''
-rule minus_condition {
-    condition:
-        filesize - 10
-}''')
-
-        self.assertEqual(len(yara_file.rules), 1)
-
-        rule = yara_file.rules[0]
-        self.assertTrue(isinstance(rule.condition, yaramod.MinusExpression))
-        self.assertTrue(isinstance(rule.condition.left_operand, yaramod.KeywordExpression))
-        self.assertTrue(isinstance(rule.condition.right_operand, yaramod.IntLiteralExpression))
-        self.assertEqual(rule.condition.text, 'filesize - 10')
 
     def test_minus_condition(self):
         yara_file = yaramod.parse_string('''
@@ -674,21 +659,6 @@ rule bitwise_and_condition {
         self.assertTrue(isinstance(rule.condition.left_operand, yaramod.KeywordExpression))
         self.assertTrue(isinstance(rule.condition.right_operand, yaramod.IntLiteralExpression))
         self.assertEqual(rule.condition.text, 'filesize & 10')
-
-    def test_bitwise_or_condition(self):
-        yara_file = yaramod.parse_string('''
-rule bitwise_or_condition {
-    condition:
-        filesize | 10
-}''')
-
-        self.assertEqual(len(yara_file.rules), 1)
-
-        rule = yara_file.rules[0]
-        self.assertTrue(isinstance(rule.condition, yaramod.BitwiseOrExpression))
-        self.assertTrue(isinstance(rule.condition.left_operand, yaramod.KeywordExpression))
-        self.assertTrue(isinstance(rule.condition.right_operand, yaramod.IntLiteralExpression))
-        self.assertEqual(rule.condition.text, 'filesize | 10')
 
     def test_bitwise_or_condition(self):
         yara_file = yaramod.parse_string('''


### PR DESCRIPTION
By chance, I found out that there are duplicate unit tests (they have both the same name and content). I found it a bit confusing, so I removed them, as it was probably only some copy-paste error. Is some cases, I figured out what probably should have been tested by the duplicate test. For example, there were two identical tests for structure access, but no test for array or dictionary access. In those cases, I didn't remove the test and I only fixed it.